### PR TITLE
Remove "evaluation version" feature

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -426,14 +426,5 @@ docs/version.entities
 tools/Makefile
 ])
 
-dnl Allow mainainer to build eval version
-AC_ARG_ENABLE(eval,
-    [  --enable-eval           Build the evaluation version of the plug-in (Disabled by default)],
-    [if test x$enableval = xyes; then
-        AC_MSG_NOTICE([Building the EVAL version of the plug-in])
-        AC_DEFINE(EVAL, 1, [Define this to build the evaluation version of the plug-in])
-    fi]
-)
-
 AC_OUTPUT
 

--- a/plugins/tracers/gstbitrate.c
+++ b/plugins/tracers/gstbitrate.c
@@ -44,10 +44,6 @@ GST_DEBUG_CATEGORY_STATIC (gst_bitrate_debug);
 G_DEFINE_TYPE_WITH_CODE (GstBitrateTracer, gst_bitrate_tracer,
     GST_TYPE_TRACER, _do_init);
 
-#ifdef EVAL
-#define EVAL_TIME (10)
-#endif
-
 #ifdef GST_STABLE_RELEASE
 static GstTracerRecord *tr_bitrate;
 #endif
@@ -160,13 +156,6 @@ add_bytes (GstBitrateTracer * self, GstClockTime ts, GstPad * pad,
   gchar *fullname;
   gint value = 1;
   GstBitrateHash *pad_frames;
-
-#ifdef EVAL
-  if (ts > EVAL_TIME * GST_SECOND) {
-    self->start_timer = FALSE;
-    return;
-  }
-#endif
 
   /* The full name of every pad has the format elementName.padName and it is going 
      to be used for displaying the bitrate in a friendly user way */

--- a/plugins/tracers/gstcpuusage.c
+++ b/plugins/tracers/gstcpuusage.c
@@ -51,10 +51,6 @@ GST_DEBUG_CATEGORY_STATIC (gst_cpuusage_debug);
 G_DEFINE_TYPE_WITH_CODE (GstCPUUsageTracer, gst_cpuusage_tracer,
     GST_TYPE_TRACER, _do_init);
 
-#ifdef EVAL
-#define EVAL_TIME (10)
-#endif
-
 #ifdef GST_STABLE_RELEASE
 static GstTracerRecord *tr_cpuusage;
 #endif
@@ -119,10 +115,6 @@ cpu_usage_thread_func (gpointer data)
   gint cpu_id;
   gint cpu_load_len;
 
-#ifdef EVAL
-  static gint sec_counter = 0;
-#endif
-
   self = GST_CPUUSAGE_TRACER (data);
 
   cpu_usage = &self->cpu_usage;
@@ -142,14 +134,6 @@ cpu_usage_thread_func (gpointer data)
 #endif
   }
   do_print_cpuusage_event (CPUUSAGE_EVENT_ID, cpu_load_len, cpu_load);
-
-#ifdef EVAL
-  sec_counter++;
-  if (sec_counter > EVAL_TIME) {
-    self->source_id = 0;
-    return FALSE;
-  }
-#endif
 
   return TRUE;
 }

--- a/plugins/tracers/gstframerate.c
+++ b/plugins/tracers/gstframerate.c
@@ -51,10 +51,6 @@ GST_DEBUG_CATEGORY_STATIC (GST_CAT_STATES);
 G_DEFINE_TYPE_WITH_CODE (GstFramerateTracer, gst_framerate_tracer,
     GST_TYPE_TRACER, _do_init);
 
-#ifdef EVAL
-#define EVAL_TIME (10)
-#endif
-
 #ifdef GST_STABLE_RELEASE
 static GstTracerRecord *tr_framerate;
 #endif
@@ -176,13 +172,6 @@ do_pad_push_buffer_pre (GstFramerateTracer * self, guint64 ts, GstPad * pad,
   gchar *fullname;
   gint value = 1;
   GstFramerateHash *pad_frames;
-
-#ifdef EVAL
-  if (ts > EVAL_TIME * GST_SECOND) {
-    self->start_timer = FALSE;
-    return;
-  }
-#endif
 
   g_return_if_fail (pad);
 

--- a/plugins/tracers/gstinterlatency.c
+++ b/plugins/tracers/gstinterlatency.c
@@ -53,10 +53,6 @@ GST_DEBUG_CATEGORY_STATIC (gst_interlatency_debug);
 G_DEFINE_TYPE_WITH_CODE (GstInterLatencyTracer, gst_interlatency_tracer,
     GST_TYPE_TRACER, _do_init);
 
-#ifdef EVAL
-#define EVAL_TIME (10)
-#endif
-
 static GQuark latency_probe_id;
 static GQuark latency_probe_pad;
 static GQuark latency_probe_ts;
@@ -172,12 +168,6 @@ static void
 calculate_latency (GstInterLatencyTracer * interlatency_tracer,
     GstElement * parent, GstPad * pad, guint64 ts)
 {
-
-#ifdef EVAL
-  if (ts > EVAL_TIME * GST_SECOND)
-    return;
-#endif
-
   if (parent && (!GST_IS_BIN (parent))) {
     GstEvent *ev = g_object_get_qdata ((GObject *) pad, latency_probe_id);
 

--- a/plugins/tracers/gstproctime.c
+++ b/plugins/tracers/gstproctime.c
@@ -48,10 +48,6 @@ GST_DEBUG_CATEGORY_STATIC (gst_proctime_debug);
 G_DEFINE_TYPE_WITH_CODE (GstProcTimeTracer, gst_proctime_tracer,
     GST_TYPE_TRACER, _do_init);
 
-#ifdef EVAL
-#define EVAL_TIME (10)
-#endif
-
 #ifdef GST_STABLE_RELEASE
 static GstTracerRecord *tr_proctime;
 #endif
@@ -77,11 +73,6 @@ do_push_buffer_pre (GstTracer * self, guint64 ts, GstPad * pad)
   gchar *name;
   GstClockTime time;
   GString *time_string = NULL;
-
-#ifdef EVAL
-  if (ts > EVAL_TIME * GST_SECOND)
-    return;
-#endif
 
   proc_time_tracer = GST_PROCTIME_TRACER_CAST (self);
   proc_time = &proc_time_tracer->proc_time;

--- a/plugins/tracers/gstqueuelevel.c
+++ b/plugins/tracers/gstqueuelevel.c
@@ -40,10 +40,6 @@ GST_DEBUG_CATEGORY_STATIC (gst_queue_level_debug);
 G_DEFINE_TYPE_WITH_CODE (GstQueueLevelTracer, gst_queue_level_tracer,
     GST_TYPE_TRACER, _do_init);
 
-#ifdef EVAL
-#define EVAL_TIME (10)
-#endif
-
 static void do_queue_level (GstTracer * self, guint64 ts, GstPad * pad);
 static void forward_to_peer (GstTracer * self, guint64 ts, GstPad * pad);
 static gboolean is_queue (GstElement * element);
@@ -96,12 +92,6 @@ do_queue_level (GstTracer * self, guint64 ts, GstPad * pad)
   guint64 size_time;
   gchar *size_time_string;
   const gchar *element_name;
-
-#ifdef EVAL
-  if (ts > EVAL_TIME * GST_SECOND) {
-    return;
-  }
-#endif
 
   element = gst_pad_get_parent_element (pad);
 

--- a/plugins/tracers/gstscheduletime.c
+++ b/plugins/tracers/gstscheduletime.c
@@ -50,10 +50,6 @@ G_DEFINE_TYPE_WITH_CODE (GstScheduletimeTracer, gst_scheduletime_tracer,
 
 #define PAD_NAME_SIZE  (64)
 
-#ifdef EVAL
-#define EVAL_TIME (10)
-#endif
-
 #ifdef GST_STABLE_RELEASE
 static GstTracerRecord *tr_schedule;
 #endif
@@ -93,11 +89,6 @@ sched_time_compute (GstTracer * self, guint64 ts, GstPad * pad)
   GString *time_string = NULL;
   gchar pad_name[PAD_NAME_SIZE];
   guint64 time_diff;
-
-#ifdef EVAL
-  if (ts > EVAL_TIME * GST_SECOND)
-    return;
-#endif
 
   obj = (GObject *) self;
   schedule_time_tracer = GST_SCHEDULETIME_TRACER_CAST (self);

--- a/plugins/tracers/gstsharktracers.c
+++ b/plugins/tracers/gstsharktracers.c
@@ -77,30 +77,6 @@ plugin_init (GstPlugin * plugin)
   if (!gst_ctf_init ()) {
     return FALSE;
   }
-#ifdef EVAL
-  g_print ("\n"
-      "*************************************\n"
-      "*** THIS IS AN EVALUATION VERSION ***\n"
-      "*************************************\n"
-      "                                     \n"
-      "  Thanks for evaluating Gst-Shark!   \n"
-      "                                     \n"
-      "  The application will run fully for \n"
-      "  around 10 seconds, after that every\n"
-      "  output will be disabled and you    \n"
-      "  will not be able to check any other\n"
-      "  message from any tracer. Please    \n"
-      "  contact <support@ridgerun.com> to  \n"
-      "  purchase the professional version  \n"
-      "  of the application.                \n"
-      "                                     \n"
-      "*************************************\n"
-      "*** THIS IS AN EVALUATION VERSION ***\n"
-      "*************************************\n"
-      "                                     \n");
-
-  sleep (3);
-#endif
 
   return TRUE;
 }


### PR DESCRIPTION
I believe it is a leftover from times where this plugin
was not intended to be under LGPL license.