### PR TITLE
fix plugin name

### DIFF
--- a/plugins/tracers/gstsharktracers.c
+++ b/plugins/tracers/gstsharktracers.c
@@ -82,5 +82,5 @@ plugin_init (GstPlugin * plugin)
 }
 
 GST_PLUGIN_DEFINE (GST_VERSION_MAJOR, GST_VERSION_MINOR,
-    gstsharktracers, "GstShark tracers", plugin_init, VERSION,
+    sharktracers, "GstShark tracers", plugin_init, VERSION,
     GST_SHARK_LICENSE, PACKAGE_NAME, PACKAGE_URL);


### PR DESCRIPTION
Recent versions of GStreamer are expecting to have the plugin name
matching the so file name.

With those versions, the plugin loader was looking for the
'gst_plugin_sharktracers_get_desc' symbol while 'gst_plugin_gstsharktracers_get_desc'
was defined.

Fix this by removing the 'gst' prefix in the plugin name.