### PR TITLE
Fix Segfault on iMX6

### DIFF
--- a/plugins/tracers/gstbitrate.c
+++ b/plugins/tracers/gstbitrate.c
@@ -226,8 +226,9 @@ gst_bitrate_tracer_class_init (GstBitrateTracerClass * klass)
           "type", G_TYPE_GTYPE, G_TYPE_UINT64,
           "description", G_TYPE_STRING, "Bitrate",
           "flags", GST_TYPE_TRACER_VALUE_FLAGS,
-          GST_TRACER_VALUE_FLAGS_AGGREGATED, "min", G_TYPE_UINT64, 0, "max",
-          G_TYPE_UINT64, G_MAXUINT64, NULL), NULL);
+          GST_TRACER_VALUE_FLAGS_AGGREGATED, "min", G_TYPE_UINT64,
+          G_GUINT64_CONSTANT (0), "max", G_TYPE_UINT64, G_MAXUINT64, NULL),
+      NULL);
 }
 
 static void

--- a/plugins/tracers/gstbuffer.c
+++ b/plugins/tracers/gstbuffer.c
@@ -81,7 +81,7 @@ gst_buffer_buffer_pre (GObject * self, GstClockTime ts, GstPad * pad,
   gchar *sduration;
   guint64 offset;
   guint64 offset_end;
-  gsize size;
+  guint64 size;
   GstBufferFlags flags;
   GValue vflags = G_VALUE_INIT;
   gchar *sflags;
@@ -164,14 +164,15 @@ gst_buffer_tracer_class_init (GstBufferTracerClass * klass)
           "description", G_TYPE_STRING, "Duration", NULL), "offset",
       GST_TYPE_STRUCTURE, gst_structure_new ("value", "type", G_TYPE_GTYPE,
           G_TYPE_UINT64, "description", G_TYPE_STRING, "Offset", "min",
-          G_TYPE_UINT64, 0, "max", G_TYPE_UINT64, G_MAXUINT64, NULL),
-      "offset_end", GST_TYPE_STRUCTURE, gst_structure_new ("value", "type",
-          G_TYPE_GTYPE, G_TYPE_UINT64, "description", G_TYPE_STRING,
-          "Offset End", "min", G_TYPE_UINT64, 0, "max", G_TYPE_UINT64,
-          G_MAXUINT64, NULL), "size", GST_TYPE_STRUCTURE,
+          G_TYPE_UINT64, G_GUINT64_CONSTANT (0), "max", G_TYPE_UINT64,
+          G_MAXUINT64, NULL), "offset_end", GST_TYPE_STRUCTURE,
       gst_structure_new ("value", "type", G_TYPE_GTYPE, G_TYPE_UINT64,
-          "description", G_TYPE_STRING, "Data Size", "min", G_TYPE_UINT64, 0,
-          "max", G_TYPE_UINT64, G_MAXUINT64, NULL), "flags", GST_TYPE_STRUCTURE,
+          "description", G_TYPE_STRING, "Offset End", "min", G_TYPE_UINT64,
+          G_GUINT64_CONSTANT (0), "max", G_TYPE_UINT64, G_MAXUINT64, NULL),
+      "size", GST_TYPE_STRUCTURE, gst_structure_new ("value", "type",
+          G_TYPE_GTYPE, G_TYPE_UINT64, "description", G_TYPE_STRING,
+          "Data Size", "min", G_TYPE_UINT64, G_GUINT64_CONSTANT (0), "max",
+          G_TYPE_UINT64, G_MAXUINT64, NULL), "flags", GST_TYPE_STRUCTURE,
       gst_structure_new ("value", "type", G_TYPE_GTYPE, G_TYPE_STRING,
           "description", G_TYPE_STRING, "Flags", NULL), "refcount",
       GST_TYPE_STRUCTURE, gst_structure_new ("value", "type", G_TYPE_GTYPE,


### PR DESCRIPTION
Bitrate and Buffer tracers guint64 definitions were causing problems
on the iMX6. Initializing the minimum value with G_GUINT64_CONSTANT
helps to avoid the issue.