### PR TITLE
Fix timestamp minimum in plot_tracer when plotting traces

### DIFF
--- a/scripts/graphics/plot_tracer.m
+++ b/scripts/graphics/plot_tracer.m
@@ -28,11 +28,12 @@ function plot_tracer(tracer,savefig,format,legend_location)
 
         # Calculate the greatest time value
         timestamp_max = max(max(tracer.cpuusage.timestamp_mat));
+        timestamp_min = min(min(tracer.cpuusage.timestamp_mat));
 
         title('CPU usage','fontsize',FONTSIZE)
         xlabel('time (seconds)','fontsize',FONTSIZE)
         ylabel('Usage (%)','fontsize',FONTSIZE)
-        xlim([0,timestamp_max])
+        xlim([timestamp_min,timestamp_max])
         if (0 == strcmp(legend_location,'extern'))
             switch CPU_USAGE_AVERAGE
                 case 0
@@ -77,13 +78,14 @@ function plot_tracer(tracer,savefig,format,legend_location)
     if (1 == isfield(tracer,'framerate'))
         # Calculate the greatest time value
         timestamp_max = max(max(tracer.framerate.timestamp_mat));
+        timestamp_min = min(min(tracer.framerate.timestamp_mat));
 
         figure('Name','Frame rate')
         plot(tracer.framerate.timestamp_mat',tracer.framerate.fps_mat','linewidth',LINEWIDTH)
         title('Frame rate','fontsize',FONTSIZE)
         xlabel('time (seconds)','fontsize',FONTSIZE)
         ylabel('Frame per second','fontsize',FONTSIZE)
-        xlim([0,timestamp_max])
+        xlim([timestamp_min,timestamp_max])
         if (0 == strcmp(legend_location,'extern'))
             legend(str2latex(tracer.framerate.element_name_list),'Location',legend_location)
         end
@@ -109,13 +111,14 @@ function plot_tracer(tracer,savefig,format,legend_location)
     if (1 == isfield(tracer,'interlatency'))
         # Calculate the greatest time value
         timestamp_max = max(max(tracer.interlatency.timestamp_mat));
+        timestamp_min = min(min(tracer.interlatency.timestamp_mat));
         
         figure('Name','Interlatency')
         plot(tracer.interlatency.timestamp_mat',tracer.interlatency.time_mat','linewidth',LINEWIDTH)
         title('Interlatency','fontsize',FONTSIZE)
         xlabel('time (seconds)','fontsize',FONTSIZE)
         ylabel('time (nanoseconds)','fontsize',FONTSIZE)
-        xlim([0,timestamp_max])
+        xlim([timestamp_min,timestamp_max])
         if (0 == strcmp(legend_location,'extern'))
             legend(str2latex(tracer.interlatency.pad_name_list),'Location',legend_location)
         end
@@ -141,13 +144,14 @@ function plot_tracer(tracer,savefig,format,legend_location)
     if (1 == isfield(tracer,'proctime'))
         # Calculate the greatest time value
         timestamp_max = max(max(tracer.proctime.timestamp_mat));
+        timestamp_min = min(min(tracer.proctime.timestamp_mat));
 
         figure('Name','Processing time')
         plot(tracer.proctime.timestamp_mat',tracer.proctime.time_mat','linewidth',LINEWIDTH)
         title('Processing time','fontsize',FONTSIZE)
         xlabel('time (seconds)','fontsize',FONTSIZE)
         ylabel('time (nanoseconds)','fontsize',FONTSIZE)
-        xlim([0,timestamp_max])
+        xlim([timestamp_min,timestamp_max])
         if (0 == strcmp(legend_location,'extern'))
             legend(str2latex(tracer.proctime.element_name_list),'Location',legend_location)
         end
@@ -173,13 +177,14 @@ function plot_tracer(tracer,savefig,format,legend_location)
     if (1 == isfield(tracer,'scheduling'))
         # Calculate the greatest time value
         timestamp_max = max(max(tracer.scheduling.timestamp_mat));
+        timestamp_min = min(min(tracer.scheduling.timestamp_mat));
 
         figure('Name','Schedule')
         plot(tracer.scheduling.timestamp_mat',tracer.scheduling.time_mat','linewidth',LINEWIDTH)
         title('Schedule','fontsize',FONTSIZE)
         xlabel('time (seconds)','fontsize',FONTSIZE)
         ylabel('time (nanoseconds)','fontsize',FONTSIZE)
-        xlim([0,timestamp_max])
+        xlim([timestamp_min,timestamp_max])
         if (0 == strcmp(legend_location,'extern'))
             legend(str2latex(tracer.scheduling.pad_name_list),'Location',legend_location)
         end
@@ -205,13 +210,14 @@ function plot_tracer(tracer,savefig,format,legend_location)
     if (1 == isfield(tracer,'bitrate'))
         # Calculate the greatest time value
         timestamp_max = max(max(tracer.bitrate.timestamp_mat));
+        timestamp_min = min(min(tracer.bitrate.timestamp_mat));
 
         figure('Name','Bitrate')
         plot(tracer.bitrate.timestamp_mat',tracer.bitrate.bitrate_mat','linewidth',LINEWIDTH)
         title('Bitrate','fontsize',FONTSIZE)
         xlabel('time (seconds)','fontsize',FONTSIZE)
         ylabel('time (nanoseconds)','fontsize',FONTSIZE)
-        xlim([0,timestamp_max])
+        xlim([timestamp_min,timestamp_max])
         if (0 == strcmp(legend_location,'extern'))
             legend(str2latex(tracer.bitrate.pad_name_list),'Location',legend_location)
         end
@@ -237,13 +243,14 @@ function plot_tracer(tracer,savefig,format,legend_location)
     if (1 == isfield(tracer,'queuelevel'))
         # Calculate the greatest time value
         timestamp_max = max(max(tracer.queuelevel.timestamp_mat));
+        timestamp_min = min(min(tracer.queuelevel.timestamp_mat));
 
         figure('Name','Queuelevel')
         plot(tracer.queuelevel.timestamp_mat',tracer.queuelevel.size_buffers_mat','linewidth',LINEWIDTH)
         title('Queuelevel','fontsize',FONTSIZE)
         xlabel('time (seconds)','fontsize',FONTSIZE)
         ylabel('Number of Buffers','fontsize',FONTSIZE)
-        xlim([0,timestamp_max])
+        xlim([timestamp_min,timestamp_max])
         if (0 == strcmp(legend_location,'extern'))
             legend(str2latex(tracer.queuelevel.element_name_list),'Location',legend_location)
         end
@@ -272,6 +279,7 @@ function plot_tracer(tracer,savefig,format,legend_location)
         legend_list{end+1} = tracer.cpuusage.cpu_name_list{1};
 
         timestamp_max = max(max(max(tracer.framerate.timestamp_mat)),max(tracer.cpuusage.timestamp_mat(:,1)));
+        timestamp_min = min(min(min(tracer.framerate.timestamp_mat)),min(tracer.cpuusage.timestamp_mat(:,1)));
 
         figure('Name','Frame rate and CPU usage')
         [hAx,hLine1,hLine2] = plotyy(tracer.framerate.timestamp_mat',tracer.framerate.fps_mat',tracer.cpuusage.timestamp_mat(:,1),tracer.cpuusage.cpu_mat(:,1));
@@ -283,7 +291,7 @@ function plot_tracer(tracer,savefig,format,legend_location)
         xlabel('time (seconds)','fontsize',FONTSIZE)
         ylabel(hAx(1),'FPS','fontsize',FONTSIZE)
         ylabel(hAx(2),'CPU usage (%)','fontsize',FONTSIZE)
-        xlim([0,timestamp_max])
+        xlim([timestamp_min,timestamp_max])
 
         if (TRUE == savefig)
             disp('Save cpuusage vs framerate figure...')


### PR DESCRIPTION
When a streamer client is started before a stream server, there was a time offset until the stream server started. This was caused by defining 0 as x min limit instead of computing the minimum timestamp of each trace. Thus, this fix changes the starting x limit from 0 to the minimum calculated in the timestamps of each trace.