### PR TITLE
Change plotting tool from default to gnuplot

### DIFF
--- a/scripts/graphics/gstshark-plot.m
+++ b/scripts/graphics/gstshark-plot.m
@@ -4,6 +4,7 @@ GSTSHARK_SAVEFIG = 0;
 GSTSHARK_SAVEFIG_FORMAT = 'pdf';
 GSTSHARK_LEGEND = 'northeast';
 TRUE = 1;
+graphics_toolkit("gnuplot");
 
 arg_list = argv ();
 


### PR DESCRIPTION
This feature fixes the bug caused by using FLTK as plotting tool. This is a bug which appears when Octave tries to launch multiple plots and it is a known issue in Octave (http://savannah.gnu.org/bugs/?45298). In gstshark-plot, a crash happens when it tries to plot multiple traces. In order to fix it, FLTK is replaced by GNU Plot as plotting tool.