### PR TITLE
Fix/cpuusage-negative-values

### DIFF
--- a/plugins/tracers/gstcpuusagecompute.h
+++ b/plugins/tracers/gstcpuusagecompute.h
@@ -24,7 +24,7 @@
 #include <gst/gst.h>
 
 G_BEGIN_DECLS
-#define CPU_NUM_MAX  8
+#define CPU_NUM_MAX  16
 /* Returns a reference to the array the contains the cpu usage computed */
 #define CPU_USAGE_ARRAY(cpuusage_struct)  (cpuusage_struct->cpu_load)
 /* Returns how many element contains the cpu_usage array

--- a/plugins/tracers/gstcpuusagecompute.h
+++ b/plugins/tracers/gstcpuusagecompute.h
@@ -24,7 +24,7 @@
 #include <gst/gst.h>
 
 G_BEGIN_DECLS
-#define CPU_NUM_MAX  16
+#define CPU_NUM_MAX  512
 /* Returns a reference to the array the contains the cpu usage computed */
 #define CPU_USAGE_ARRAY(cpuusage_struct)  (cpuusage_struct->cpu_load)
 /* Returns how many element contains the cpu_usage array


### PR DESCRIPTION
The cpuusage tracer will output negative values if the system has more cores than the specified when compiling in CPU_NUM_MAX (8)

A better approach would be have a couple of options to set this:
1. Get the number of processors while configuring the project, when natively compiling the project
2. Set the number of processors when cross-compiling

For now this is just a quick fix to avoid this issue when using a nowadays typical computer with more than 8 cores.