### PR TITLE
Fix critical warnings when using buffer tracer

### DIFF
--- a/plugins/tracers/gstsharktracer.c
+++ b/plugins/tracers/gstsharktracer.c
@@ -468,7 +468,7 @@ gst_shark_tracer_hook_pad_push_list_pre (GObject * object, GstClockTime ts,
     return;
   }
 
-  hook = g_hash_table_lookup (priv->hooks, "pad-push-pre");
+  hook = g_hash_table_lookup (priv->hooks, "pad-push-list-pre");
   g_return_if_fail (hook);
 
   ((void (*)(GObject *, GstClockTime, GstPad *, GstBufferList *)) hook) (object,


### PR DESCRIPTION
This fixes a copy-paste mistake that caused a bunch of critical warnings:

```log
GStreamer-CRITICAL **: 11:38:05.911: gst_buffer_get_size: assertion 'GST_IS_BUFFER (buffer)' failed

GStreamer-CRITICAL **: 11:38:05.911: gst_buffer_get_size: assertion 'GST_IS_BUFFER (buffer)' failed

GStreamer-CRITICAL **: 11:38:05.911: gst_buffer_get_size: assertion 'GST_IS_BUFFER (buffer)' failed

GStreamer-CRITICAL **: 11:38:05.911: gst_buffer_get_size: assertion 'GST_IS_BUFFER (buffer)' failed

GStreamer-CRITICAL **: 11:38:05.911: gst_buffer_get_size: assertion 'GST_IS_BUFFER (buffer)' failed

GStreamer-CRITICAL **: 11:38:05.911: gst_buffer_get_size: assertion 'GST_IS_BUFFER (buffer)' failed
```

This is caused because buffer lists are passed to the function meant to process buffers. This causes at least the buffer tracer to not work for buffer lists.