### PR TITLE
Add base classes to core shark library

### DIFF
--- a/plugins/tracers/meson.build
+++ b/plugins/tracers/meson.build
@@ -4,7 +4,9 @@ libgst_shark_src_files = [
   'gstcpuusagecompute.c',
   'gstproctimecompute.c',
   'gstctf.c',
-  'gstparser.c'
+  'gstparser.c',
+  'gstsharktracer.c',
+  'gstperiodictracer.c'
 ]
 
 libgst_shark_c_args = [gst_c_args,
@@ -25,9 +27,32 @@ gst_shark_lib = both_libraries('gstshark',
 # Define the library as an internal dependency to the tracers library
 lib_gst_shark_dep = declare_dependency(link_with: gst_shark_lib, dependencies : [gst_shark_deps])
 
+install_headers(
+  [
+    'gstsharktracer.h',
+    'gstperiodictracer.h',
+  ],
+  subdir : join_paths('gst', 'shark')
+)
+
+pkgconfig = import('pkgconfig')
+
+pkgconfig.generate(
+  libraries : gst_shark_lib,
+  version : gst_shark_version_short,
+  name : 'gstshark',
+  filebase : 'gstshark',
+  description : 'GstShark tracing core library',
+  subdirs : 'gst',
+  requires : ['gstreamer-1.0', 'gstreamer-base-1.0'],
+  variables : {
+    'exec_prefix' : '${prefix}',
+  }
+)
+
+# Tracers
 libgst_shark_tracers_src_files = [
   'gstplugin.c',
-  'gstsharktracer.c',
   'gstgraphic.c',
   'gstcpuusage.c',
   'gstproctime.c',
@@ -36,8 +61,7 @@ libgst_shark_tracers_src_files = [
   'gstframerate.c',
   'gstqueuelevel.c',
   'gstbitrate.c',
-  'gstbuffer.c',
-  'gstperiodictracer.c'
+  'gstbuffer.c'
 ]
 
 gst_shark_tracers_plugins = both_libraries('gstsharktracers',


### PR DESCRIPTION
This adds base classes to core shark library to allow its usage in external projects. Install corresponding headers and generates .pc.