### PR TITLE
Move add metadata to constructed after ctf initialization

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ dnl when going to/from release please set the nano (fourth number) right !
 dnl releases only do Wall, git and prerelease does Werror too
 dnl
 AC_INIT([GstShark],
-        [0.9.0.1],
+        [0.9.1.1],
 	[https://github.com/RidgeRun/gst-shark],
 	[gst-shark],
 	[https://github.com/RidgeRun/gst-shark])

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@
 #           Roberto Gutierrez <roberto.gutierrez@ridgerun.com>
 
 project('gst-shark', 'c',
-  version : '0.9.0',
+  version : '0.9.1',
   meson_version : '>= 0.58',)
 
 # Project version

--- a/plugins/tracers/gstinterlatency.c
+++ b/plugins/tracers/gstinterlatency.c
@@ -74,6 +74,7 @@ static const gchar interlatency_metadata_event[] = "event {\n\
 \n";
 
 static void gst_interlatency_tracer_dispose (GObject * object);
+static void gst_interlatency_tracer_constructed (GObject *object);
 
 /* data helpers */
 
@@ -311,13 +312,13 @@ gst_interlatency_tracer_class_init (GstInterLatencyTracerClass * klass)
   /* *INDENT-ON* */
 
   oclass->dispose = gst_interlatency_tracer_dispose;
+  oclass->constructed = gst_interlatency_tracer_constructed;
 }
 
 static void
 gst_interlatency_tracer_init (GstInterLatencyTracer * self)
 {
   GstTracer *tracer = GST_TRACER (self);
-  gchar *metadata_event = NULL;
 
   /* In push mode, pre/post will be called before/after the peer chain
    * function has been called. For this reason, we only use -pre to avoid
@@ -340,13 +341,23 @@ gst_interlatency_tracer_init (GstInterLatencyTracer * self)
   gst_tracing_register_hook (tracer, "pad-push-event-pre",
       G_CALLBACK (do_push_event_pre));
 
-  metadata_event =
-      g_strdup_printf (interlatency_metadata_event, INTERLATENCY_EVENT_ID, 0);
-  add_metadata_event_struct (metadata_event);
-  g_free (metadata_event);
 }
 
 static void
 gst_interlatency_tracer_dispose (GObject * object)
 {
+}
+
+static void
+gst_interlatency_tracer_constructed (GObject *object)
+{
+  gchar *metadata_event = NULL;
+
+  /* chain up so parent constructed runs first (calls gst_ctf_init) */
+  G_OBJECT_CLASS (gst_interlatency_tracer_parent_class)->constructed (object);
+
+  metadata_event =
+      g_strdup_printf (interlatency_metadata_event, INTERLATENCY_EVENT_ID, 0);
+  add_metadata_event_struct (metadata_event);
+  g_free (metadata_event);
 }

--- a/plugins/tracers/gstproctime.c
+++ b/plugins/tracers/gstproctime.c
@@ -49,6 +49,8 @@ struct _GstProcTimeTracer
 G_DEFINE_TYPE_WITH_CODE (GstProcTimeTracer, gst_proc_time_tracer,
     GST_SHARK_TYPE_TRACER, _do_init);
 
+static void gst_proc_time_tracer_constructed (GObject *object);
+
 static GstTracerRecord *tr_proc_time;
 
 static const gchar proc_time_metadata_event[] = "event {\n\
@@ -136,7 +138,7 @@ gst_proc_time_tracer_class_init (GstProcTimeTracerClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
 
-
+  gobject_class->constructed = gst_proc_time_tracer_constructed;
   gobject_class->finalize = gst_proc_time_tracer_finalize;
 
   tr_proc_time = gst_tracer_record_new ("proctime.class",
@@ -154,7 +156,6 @@ static void
 gst_proc_time_tracer_init (GstProcTimeTracer * self)
 {
   GstTracer *tracer = GST_TRACER (self);
-  gchar *metadata_event = NULL;
 
   self->proc_time = gst_proctime_new ();
 
@@ -163,6 +164,16 @@ gst_proc_time_tracer_init (GstProcTimeTracer * self)
 
   gst_tracing_register_hook (tracer, "element-new",
       G_CALLBACK (do_element_new));
+}
+
+
+static void
+gst_proc_time_tracer_constructed (GObject *object)
+{
+  gchar *metadata_event = NULL;
+
+  /* chain up so parent constructed runs first (calls gst_ctf_init) */
+  G_OBJECT_CLASS (gst_proc_time_tracer_parent_class)->constructed (object);
 
   metadata_event =
       g_strdup_printf (proc_time_metadata_event, PROCTIME_EVENT_ID, 0);

--- a/plugins/tracers/gstscheduletime.c
+++ b/plugins/tracers/gstscheduletime.c
@@ -69,6 +69,7 @@ static void sched_time_compute (GstTracer * tracer, guint64 ts, GstPad * pad);
 static void do_push_buffer_list_pre (GstTracer * tracer, GstClockTime ts,
     GstPad * pad, GstBufferList * list);
 static void gst_scheduletime_tracer_finalize (GObject * obj);
+static void gst_scheduletime_tracer_constructed (GObject *object);
 
 static void
 key_destroy (gpointer pad)
@@ -156,6 +157,7 @@ gst_scheduletime_tracer_class_init (GstScheduletimeTracerClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
 
+  gobject_class->constructed = gst_scheduletime_tracer_constructed;
   gobject_class->finalize = gst_scheduletime_tracer_finalize;
 
   tr_schedule = gst_tracer_record_new ("scheduletime.class",
@@ -173,7 +175,6 @@ static void
 gst_scheduletime_tracer_init (GstScheduletimeTracer * self)
 {
   GstSharkTracer *tracer = GST_SHARK_TRACER (self);
-  gchar *metadata_event = NULL;
 
   self->schedule_pads =
       g_hash_table_new_full (g_direct_hash, g_direct_equal, key_destroy,
@@ -187,6 +188,16 @@ gst_scheduletime_tracer_init (GstScheduletimeTracer * self)
 
   gst_shark_tracer_register_hook (tracer, "pad-pull-range-pre",
       G_CALLBACK (sched_time_compute));
+
+}
+
+static void
+gst_scheduletime_tracer_constructed (GObject *object)
+{
+  gchar *metadata_event = NULL;
+
+  /* chain up so parent constructed runs first (calls gst_ctf_init) */
+  G_OBJECT_CLASS (gst_scheduletime_tracer_parent_class)->constructed (object);
 
   metadata_event =
       g_strdup_printf (scheduling_metadata_event, SCHED_TIME_EVENT_ID, 0);


### PR DESCRIPTION
This fixes crash of non-periodic tracers that were adding the event metadata at tracer init where ctf is not initialized yet, now this moves that logic to the tracer constructed after the parent constructed ensuring that ctf is initialized before the metadata is added. The tracers modified are: interlatency, proctime, queuelevel and scheduletime.